### PR TITLE
fixed a issue that causes RuntimeError in Python 3

### DIFF
--- a/scripts/PoolSnp.py
+++ b/scripts/PoolSnp.py
@@ -229,7 +229,7 @@ for line in load_data(data):
 
         alleleh = alleles[j]
         # remove alleles not counted in all samples
-        for k, v in alleleh.items():
+        for k, v in alleleh.copy().items():
             if k != REF and k not in ALT:
                 del alleleh[k]
         GT, AD, RD, FREQ, NC = [], [], 0, [], 0


### PR DESCRIPTION
Hi Martin,

It's really appreciated that you've upgraded your code to Python 3, making it more compatible with the current environment.

Recently, my colleague reported a runtime error that is caused by changing dictionary size during iteration when running PoolSNP.py. This error won't corrupt the whole script or affect the result, but people might get nervous about an 'error' being raised. Thus, I add a '.copy()' to your line 232 to avoid this issue. 

Interestingly, Python 2 won't report this runtime error when a dictionary size is changed during iteration, but Python 3 does. I also noticed you have added `.copy() `to line 198 when filtering `totalalleles` by mincount or minfreq, so you've probably realized this issue but forgot to modify the other line.