### PR TITLE
Fixed a mixed-delimiter issue of the vcf header

### DIFF
--- a/PoolSNP.sh
+++ b/PoolSNP.sh
@@ -130,7 +130,7 @@ mkdir -p $out/temp
 ###############################################
 
 ## create VCF header
-echo """##fileformat=VCFv4.2
+echo -e """##fileformat=VCFv4.2
 ##fileDate=$(date +%d'/'%m'/'%y)
 ##Source=PoolSnp-1.05
 ##Parameters=<ID=MinCov,Number=$mic,Type=Integer,Description=\"Minimum coverage per sample\">
@@ -146,8 +146,8 @@ echo """##fileformat=VCFv4.2
 ##FORMAT=<ID=RD,Number=1,Type=Integer,Description=\"Reference Counts\">
 ##FORMAT=<ID=AD,Number=1,Type=Integer,Description=\"Alternative Counts\">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">
-##FORMAT=<ID=FREQ,Number=1,Type=FLoat,Description=\"Variant allele frequency\">
-#CHROM       POS       ID       REF       ALT       QUAL       FILTER       INFO       FORMAT       $new""" > $out/temp/header.txt
+##FORMAT=<ID=FREQ,Number=1,Type=Float,Description=\"Variant allele frequency\">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t$new""" > $out/temp/header.txt
 
 ###############################################
 #### calculate max coverage when necessary ####


### PR DESCRIPTION
Hi Martin,

My colleague also noticed that there might be some formatting issue with the printed VCF header, which leads to a header error when using bcftools, and might potentially confuse some of other downstream software.

Here are two issues that I identified and managed to fix within the PoolSNP.sh script. 

1. Space delimiters at line 150 that causes a mixed-delimiter issue at the printed VCF header (space-delimited for columns before the sample names, while tab-delimited for the latter part of sample names) are replaced by consistent tab delimiters by explicitly using `\t `delimiter and the `-e `option of `echo`;
2. A type error of `Float` as `FLoat` at line 149 is also corrected.