### PR TITLE
Update python scripts path

### DIFF
--- a/PoolSNP.sh
+++ b/PoolSNP.sh
@@ -5,6 +5,10 @@
 ## Author: Martin Kapun
 ## test if Shell is indeed BASH
 
+# Specify the scripts/ directory
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$SCRIPTS_DIR/scripts"
+
 ###############################################
 ######### READ COMMANDLINE ARGUMENTS ##########
 ###############################################
@@ -196,11 +200,11 @@ if [[ $ref =~ \.gz$ ]]
 
 then
 
-gunzip -c $ref | grep '^>' | awk '$1!~/\|/ && $1!~/\// && $1!~/\\/ && $1!~/,/' | awk -v inp="$out" -v cut="$mac" ' {print "python3 scripts/max-cov.py --mpileup "inp"/temp/cov/mpileups/"substr($1,2)".mpileup.gz --cutoff "cut" --contig "substr($1,2)" --out "inp"/temp/cov/cutoffs/"substr($1,2)".txt" }' > $out/temp/contignames.txt
+gunzip -c $ref | grep '^>' | awk '$1!~/\|/ && $1!~/\// && $1!~/\\/ && $1!~/,/' | awk -v inp="$out" -v cut="$mac" -v script_dir="$SCRIPTS_DIR" '{print "python3 " script_dir "/max-cov.py --mpileup " inp "/temp/cov/mpileups/" substr($1,2) ".mpileup.gz --cutoff " cut " --contig " substr($1,2) " --out " inp "/temp/cov/cutoffs/" substr($1,2) ".txt"}' > $out/temp/contignames.txt
 
 else
 
-grep '^>' $ref | awk '$1!~/\|/ && $1!~/\// && $1!~/\\/ && $1!~/,/' | awk -v inp="$out" -v cut="$mac" '{print "python3 scripts/max-cov.py --mpileup "inp"/temp/cov/mpileups/"substr($1,2)".mpileup.gz --cutoff "cut" --contig "substr($1,2)" --out "inp"/temp/cov/cutoffs/"substr($1,2)".txt" }' > $out/temp/contignames.txt
+grep '^>' $ref | awk '$1!~/\|/ && $1!~/\// && $1!~/\\/ && $1!~/,/' | awk -v inp="$out" -v cut="$mac" -v script_dir="$SCRIPTS_DIR" '{print "python3 " script_dir "/max-cov.py --mpileup " inp "/temp/cov/mpileups/" substr($1,2) ".mpileup.gz --cutoff " cut " --contig " substr($1,2) " --out " inp "/temp/cov/cutoffs/" substr($1,2) ".txt"}' > $out/temp/contignames.txt
 
 fi
 
@@ -249,7 +253,7 @@ gunzip -c $mpileup | parallel \
 --pipe \
 -j $jobs \
 --no-notice \
---cat python3 scripts/PoolSnp.py \
+--cat python3 "$SCRIPTS_DIR/PoolSnp.py" \
 --mpileup  {} \
 --min-cov $mic \
 --max-cov  $mac \
@@ -268,7 +272,7 @@ parallel \
 --pipepart \
 --no-notice \
 -a  $mpileup \
---cat python3 scripts/PoolSnp.py \
+--cat python3 "$SCRIPTS_DIR/PoolSnp.py" \
 --mpileup  {} \
 --min-cov $mic \
 --max-cov  $mac \
@@ -314,7 +318,7 @@ gunzip -c $mpileup | parallel \
 --pipe \
 -j $jobs \
 --no-notice \
---cat python3 scripts/bad-sites.py \
+--cat python3 "$SCRIPTS_DIR/bad-sites.py" \
 --mpileup  {} \
 --min-cov $mic \
 --max-cov  $mac \
@@ -329,7 +333,7 @@ parallel \
 --pipepart \
 --no-notice \
 -a  $mpileup \
---cat python3 scripts/bad-sites.py \
+--cat python3 "$SCRIPTS_DIR/bad-sites.py" \
 --mpileup  {} \
 --min-cov $mic \
 --max-cov  $mac \


### PR DESCRIPTION
Hi Martin, 

I recently built a conda package for PoolSNP - https://anaconda.org/bioconda/poolsnp.
This took care of installing the dependencies required for PoolSNP, making the PoolSNP scripts executable and available to the `PATH` variable of the conda environment.

However, when the user runs the `PoolSNP.sh` script from a different directory, the script is unable to find the relevant `*.py` files because it's looking for the files in the `scripts/` directory which should be located at the same location as the `PoolSNP.sh` script. 

These modifications to the `PoolSNP.sh` ensure that the script can reliably locate and reference the `*.py` scripts in the `scripts/` directory, regardless of where the script is executed from.

I've tested the changes to `PoolSNP.sh` with the provided test data in two ways: 

1. Downloaded my forked github repo, and executed the `PoolSNP.sh` script as you intended, and this execution still works
2. Built a conda package with the updated code and tested it locally, ensuring that the conda package can also find the python scripts.

Please let me know what you think about these changes, merging the PR would be essential for the functioning of the conda package and it is crucial that the changes are made upstream so that the conda build process can directly pull the code from the source without any modifications. 

Could you also bump the release number (to say v1.0.1) when you merge these changes, this would ensure that the conda package picks up the latest version of the github repo.